### PR TITLE
Allow text mode for files and read shaders in text mode

### DIFF
--- a/source/globjects/include/globjects/base/File.h
+++ b/source/globjects/include/globjects/base/File.h
@@ -19,7 +19,7 @@ namespace globjects
 class GLOBJECTS_API File : public globjects::AbstractStringSource
 {
 public:
-    File(const std::string & filePath);
+    File(const std::string & filePath, bool binary = true);
 
     virtual std::string string() const override;
     virtual std::string shortInfo() const override;
@@ -32,6 +32,7 @@ public:
 
 protected:
     std::string m_filePath;
+    bool m_binary;
     mutable std::string m_source;
     mutable bool m_valid;
 

--- a/source/globjects/source/Shader.cpp
+++ b/source/globjects/source/Shader.cpp
@@ -63,7 +63,7 @@ Shader * Shader::fromString(const GLenum type, const std::string & sourceString,
 
 Shader * Shader::fromFile(const GLenum type, const std::string & filename, const IncludePaths & includePaths)
 {
-    return new Shader(type, new File(filename), includePaths);
+    return new Shader(type, new File(filename, false), includePaths);
 }
 
 Shader::~Shader()

--- a/source/globjects/source/base/File.cpp
+++ b/source/globjects/source/base/File.cpp
@@ -9,8 +9,9 @@
 namespace globjects
 {
 
-File::File(const std::string & filePath)
+File::File(const std::string & filePath, bool binary)
 : m_filePath(filePath)
+, m_binary(binary)
 , m_valid(false)
 {
     FileRegistry::registerFile(this);
@@ -52,7 +53,12 @@ void File::reloadAll()
 
 void File::loadFileContent() const
 {
-    std::ifstream ifs(m_filePath, std::ios::in | std::ios::binary | std::ios::ate);
+    std::ios::openmode mode = std::ios::in | std::ios::ate;
+    if (m_binary) {
+        mode |= std::ios::binary;
+    }
+
+    std::ifstream ifs(m_filePath, mode);
 
     if (ifs)
     {
@@ -63,6 +69,7 @@ void File::loadFileContent() const
         m_source.resize(size);
 
         ifs.read(const_cast<char*>(m_source.data()), size);
+        m_source.resize(ifs.gcount());
         ifs.close();
 
         m_valid = true;


### PR DESCRIPTION
... because processing shaders read in binary mode on Windows is rather annoying, as they contain `\r\n` line endings (possibly mixed with pure `\n`).