### PR TITLE
Add move semantics to CachedValue

### DIFF
--- a/source/globjects/include/globjects/base/CachedValue.h
+++ b/source/globjects/include/globjects/base/CachedValue.h
@@ -31,12 +31,14 @@ class CachedValue
 public:
 	CachedValue();
 	CachedValue(const T & value);
+    CachedValue(T && value);
 
 	bool isValid() const;
 	
 	T & value();
 	const T & value() const;
-	void setValue(const T & value, bool validate = true) const;
+    void setValue(const T & value, bool validate = true) const;
+    void setValue(T && value, bool validate = true) const;
 
 	void validate() const;
 	void invalidate() const;

--- a/source/globjects/include/globjects/base/CachedValue.hpp
+++ b/source/globjects/include/globjects/base/CachedValue.hpp
@@ -22,6 +22,13 @@ CachedValue<T>::CachedValue(const T & value)
 }
 
 template <typename T>
+CachedValue<T>::CachedValue(T && value)
+: m_valid(true)
+, m_value(std::move(value))
+{
+}
+
+template <typename T>
 bool CachedValue<T>::isValid() const
 {
     return m_valid;
@@ -46,6 +53,13 @@ void CachedValue<T>::setValue(const T & value, const bool validate) const
 {
     m_valid = validate;
     m_value = value;
+}
+
+template <typename T>
+void CachedValue<T>::setValue(T && value, const bool validate) const
+{
+    m_valid = validate;
+    m_value = std::move(value);
 }
 
 template <typename T>


### PR DESCRIPTION
Allows storing `std::unique_ptr`s in a `CachedValue`