### PR TITLE
Fix transform feedback example

### DIFF
--- a/source/examples/transformfeedback/main.cpp
+++ b/source/examples/transformfeedback/main.cpp
@@ -150,18 +150,18 @@ public:
 
         m_vao->binding(0)->setBuffer(drawBuffer, 0, sizeof(vec4));
 
+        m_transformFeedback->bind();
         writeBuffer->bindBase(GL_TRANSFORM_FEEDBACK_BUFFER, 0);
 
         glEnable(GL_RASTERIZER_DISCARD);
 
         m_transformFeedbackProgram->use();
-        m_transformFeedback->bind();
         m_transformFeedback->begin(GL_TRIANGLES);
         m_vao->drawArrays(GL_TRIANGLES, 0, 6);
         m_transformFeedback->end();
-        m_transformFeedback->unbind();
         glDisable(GL_RASTERIZER_DISCARD);
 
+        m_transformFeedback->unbind();
 
         m_vao->binding(0)->setBuffer(writeBuffer, 0, sizeof(vec4));
 


### PR DESCRIPTION
It seems that the TransformFeedback object has to be bound *before* calling glBindBufferBase on a buffer, otherwise the formerly bound buffer remains active, resulting in GL_INVALID_OPERATION ("Buffer is mapped.") errors, because the same buffer is used for reading and writing.

The example previously worked by chance, because m_transformFeedback->draw() internally calls bind(), so the object will already be bound in the next frame. Remove the draw call in the previous version of the example to reproduce the error.