### PR TITLE
Add wrappers to invalidate buffer data & texture images

### DIFF
--- a/source/globjects/include/globjects/Buffer.h
+++ b/source/globjects/include/globjects/Buffer.h
@@ -245,6 +245,18 @@ public:
     template <typename T, std::size_t Count>
     const std::array<T, Count> getSubData(gl::GLintptr offset = 0) const;
 
+    /** \brief Wraps the OpenGL function gl::glInvalidateBufferData.
+        \see https://www.opengl.org/sdk/docs/man/html/glInvalidateBufferData.xhtml
+    */
+    void invalidateData() const;
+
+    /** \brief Wraps the OpenGL function gl::glInvalidateBufferSubData.
+        \param offset offset in bytes
+        \param size size in bytes
+        \see https://www.opengl.org/sdk/docs/man/html/glInvalidateBufferSubData.xhtml
+    */
+    void invalidateSubData(gl::GLintptr offset, gl::GLsizeiptr length) const;
+
     virtual gl::GLenum objectType() const override;
 
 protected:

--- a/source/globjects/include/globjects/Texture.h
+++ b/source/globjects/include/globjects/Texture.h
@@ -109,6 +109,10 @@ public:
     void clearSubImage(gl::GLint level, const glm::ivec3 & offset, const glm::ivec3 & size, gl::GLenum format, gl::GLenum type, const glm::ivec4 & value);
     void clearSubImage(gl::GLint level, const glm::ivec3 & offset, const glm::ivec3 & size, gl::GLenum format, gl::GLenum type, const glm::uvec4 & value);
 
+    void invalidateImage(gl::GLint level) const;
+    void invalidateSubImage(gl::GLint level, gl::GLint xoffset, gl::GLint yoffset, gl::GLint zoffset, gl::GLsizei width, gl::GLsizei height, gl::GLsizei depth);
+    void invalidateSubImage(gl::GLint level, const glm::ivec3& offset, const glm::ivec3 size);
+
     void bindImageTexture(gl::GLuint unit, gl::GLint level, gl::GLboolean layered, gl::GLint layer, gl::GLenum access, gl::GLenum format) const;
     static void unbindImageTexture(gl::GLuint unit);
 

--- a/source/globjects/source/Buffer.cpp
+++ b/source/globjects/source/Buffer.cpp
@@ -195,6 +195,16 @@ void Buffer::getSubData(const GLintptr offset, const GLsizeiptr size, void * dat
     implementation().getBufferSubData(this, offset, size, data);
 }
 
+void Buffer::invalidateData() const
+{
+    implementation().invalidateData(this);
+}
+
+void Buffer::invalidateSubData(const GLintptr offset, const GLsizeiptr length) const
+{
+    implementation().invalidateSubData(this, offset, length);
+}
+
 GLenum Buffer::objectType() const
 {
     return GL_BUFFER;

--- a/source/globjects/source/Texture.cpp
+++ b/source/globjects/source/Texture.cpp
@@ -409,6 +409,21 @@ void Texture::clearSubImage(const GLint level, const glm::ivec3 & offset, const 
     clearSubImage(level, offset, size, format, type, glm::value_ptr(value));
 }
 
+void Texture::invalidateImage(GLint level) const
+{
+    glInvalidateTexImage(id(), level);
+}
+
+void Texture::invalidateSubImage(GLint level, GLint xoffset, GLint yoffset, GLint zoffset, GLsizei width, GLsizei height, GLsizei depth)
+{
+    glInvalidateTexSubImage(id(), level, xoffset, yoffset, zoffset, width, height, depth);
+}
+
+void Texture::invalidateSubImage(GLint level, const glm::ivec3& offset, const glm::ivec3 size)
+{
+    invalidateSubImage(level, offset.x, offset.y, offset.z, size.x, size.y, size.z);
+}
+
 void Texture::bindImageTexture(const GLuint unit, const GLint level, const GLboolean layered, const GLint layer, const GLenum access, const GLenum format) const
 {
 	glBindImageTexture(unit, id(), level, layered, layer, access, format);

--- a/source/globjects/source/implementations/AbstractBufferImplementation.h
+++ b/source/globjects/source/implementations/AbstractBufferImplementation.h
@@ -42,6 +42,9 @@ public:
     virtual void flushMappedRange(const Buffer * buffer, gl::GLintptr offset, gl::GLsizeiptr length) const = 0;
 
     virtual void getBufferSubData(const Buffer * buffer, gl::GLintptr offset, gl::GLsizeiptr size, gl::GLvoid * data) const = 0;
+
+    virtual void invalidateData(const Buffer * buffer) const = 0;
+    virtual void invalidateSubData(const Buffer * buffer, gl::GLintptr offset, gl::GLsizeiptr length) const = 0;
 };
 
 } // namespace globjects

--- a/source/globjects/source/implementations/BufferImplementation_DirectStateAccessARB.cpp
+++ b/source/globjects/source/implementations/BufferImplementation_DirectStateAccessARB.cpp
@@ -109,4 +109,14 @@ void BufferImplementation_DirectStateAccessARB::getBufferSubData(const Buffer * 
     glGetNamedBufferSubData(buffer->id(), offset, static_cast<GLsizei>(size), data);
 }
 
+void BufferImplementation_DirectStateAccessARB::invalidateData(const Buffer * buffer) const
+{
+    glInvalidateBufferData(buffer->id());
+}
+
+void BufferImplementation_DirectStateAccessARB::invalidateSubData(const Buffer * buffer, GLintptr offset, GLsizeiptr length) const
+{
+    glInvalidateBufferSubData(buffer->id(), offset, length);
+}
+
 } // namespace globjects

--- a/source/globjects/source/implementations/BufferImplementation_DirectStateAccessARB.h
+++ b/source/globjects/source/implementations/BufferImplementation_DirectStateAccessARB.h
@@ -37,6 +37,9 @@ public:
     virtual void flushMappedRange(const Buffer * buffer, gl::GLintptr offset, gl::GLsizeiptr length) const override;
 
     virtual void getBufferSubData(const Buffer * buffer, gl::GLintptr offset, gl::GLsizeiptr size, gl::GLvoid * data) const override;
+
+    virtual void invalidateData(const Buffer * buffer) const override;
+    virtual void invalidateSubData(const Buffer * buffer, gl::GLintptr offset, gl::GLsizeiptr length) const override;
 };
 
 } // namespace globjects

--- a/source/globjects/source/implementations/BufferImplementation_DirectStateAccessEXT.cpp
+++ b/source/globjects/source/implementations/BufferImplementation_DirectStateAccessEXT.cpp
@@ -102,4 +102,14 @@ void BufferImplementation_DirectStateAccessEXT::getBufferSubData(const Buffer * 
     glGetNamedBufferSubDataEXT(buffer->id(), offset, size, data);
 }
 
+void BufferImplementation_DirectStateAccessEXT::invalidateData(const Buffer * buffer) const
+{
+    glInvalidateBufferData(buffer->id());
+}
+
+void BufferImplementation_DirectStateAccessEXT::invalidateSubData(const Buffer * buffer, GLintptr offset, GLsizeiptr length) const
+{
+    glInvalidateBufferSubData(buffer->id(), offset, length);
+}
+
 } // namespace globjects

--- a/source/globjects/source/implementations/BufferImplementation_DirectStateAccessEXT.h
+++ b/source/globjects/source/implementations/BufferImplementation_DirectStateAccessEXT.h
@@ -37,6 +37,9 @@ public:
     virtual void flushMappedRange(const Buffer * buffer, gl::GLintptr offset, gl::GLsizeiptr length) const override;
 
     virtual void getBufferSubData(const Buffer * buffer, gl::GLintptr offset, gl::GLsizeiptr size, gl::GLvoid * data) const override;
+
+    virtual void invalidateData(const Buffer * buffer) const override;
+    virtual void invalidateSubData(const Buffer * buffer, gl::GLintptr offset, gl::GLsizeiptr length) const override;
 };
 
 } // namespace globjects

--- a/source/globjects/source/implementations/BufferImplementation_Legacy.cpp
+++ b/source/globjects/source/implementations/BufferImplementation_Legacy.cpp
@@ -5,6 +5,7 @@
 #include <glbinding/gl/boolean.h>
 #include <glbinding/gl/enum.h>
 
+#include <globjects/base/baselogging.h>
 #include <globjects/Buffer.h>
 
 
@@ -141,6 +142,16 @@ void BufferImplementation_Legacy::getBufferSubData(const Buffer * buffer, GLintp
     buffer->bind(s_workingTarget);
 
     glGetBufferSubData(s_workingTarget, offset, size, data);
+}
+
+void BufferImplementation_Legacy::invalidateData(const Buffer * /* buffer */) const
+{
+    critical() << "glInvalidateBufferData requires direct state access";
+}
+
+void BufferImplementation_Legacy::invalidateSubData(const Buffer * /* buffer */, GLintptr /* offset */, GLsizeiptr /* length */) const
+{
+    critical() << "glInvalidateBufferSubData requires direct state access";
 }
 
 } // namespace globjects

--- a/source/globjects/source/implementations/BufferImplementation_Legacy.h
+++ b/source/globjects/source/implementations/BufferImplementation_Legacy.h
@@ -36,6 +36,9 @@ public:
 
     virtual void getBufferSubData(const Buffer * buffer, gl::GLintptr offset, gl::GLsizeiptr size, gl::GLvoid * data) const override;
 
+    virtual void invalidateData(const Buffer * buffer) const override;
+    virtual void invalidateSubData(const Buffer * buffer, gl::GLintptr offset, gl::GLsizeiptr length) const override;
+
 public:
     static gl::GLenum s_workingTarget;
 };


### PR DESCRIPTION
Problem: `glInvalidateBuffer[Sub]Data` functions require direct state access and don't have equivalents in the legacy implementation; the current solution simply logs a critical error message then. How would you handle this?